### PR TITLE
Fix build configuration and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,6 @@ vendor/
 coverage.out
 
 # Config files
-config.json
-
 # Ensure no source files are ignored
 !cmd/main.go
 !internal/**/*.go

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-# Makefile for GoBuster Clone
+		# Makefile for GoBuster Clone
 
 # Variables
 # Allows the binary name to be customized using CUSTOM_BINARY_NAME; defaults to 'DirSleuth' if not specified
 BINARY_NAME=$(if $(CUSTOM_BINARY_NAME),$(CUSTOM_BINARY_NAME),DirSleuth)
-SRC=main.go
-CONFIG?=config.json
+SRC=cmd/main.go
 
 .PHONY: all build run clean test
 
@@ -16,18 +15,14 @@ build:
 	@echo "Building the project..."
 	go build -o $(BINARY_NAME) $(SRC)
 
-# Run the project with configurable config file
+# Run the project
 run: build
 	@echo "Running the project..."
 	@if [ ! -f $(BINARY_NAME) ]; then \
-		echo "Error: Binary file $(BINARY_NAME) not found. Please build the project first."; \
-		exit 1; \
+	echo "Error: Binary file $(BINARY_NAME) not found. Please build the project first."; \
+	exit 1; \
 	fi
-	@if [ ! -f $(CONFIG) ]; then \
-		echo "Error: Configuration file $(CONFIG) not found."; \
-		exit 1; \
-	fi
-	./$(BINARY_NAME) -config $(CONFIG)
+	./$(BINARY_NAME)
 
 # Clean up build artifacts
 clean:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ DirSleuth is a fast and efficient directory enumeration tool written in Go. It s
 ### Basic Command
 Run the tool with a target domain and a wordlist:
 ```bash
-./DirSleuth -domain example.com -wordlist /path/to/wordlist.txt
+./DirSleuth -d example.com -w /path/to/wordlist.txt
 ```
 
 ### Options
@@ -45,11 +45,11 @@ Run the tool with a target domain and a wordlist:
 ### Examples
 1. Scan with default settings:
    ```bash
-   ./DirSleuth -domain example.com -wordlist wordlist.txt
+    ./DirSleuth -d example.com -w wordlist.txt
    ```
 2. Customize threads and timeout:
    ```bash
-   ./DirSleuth -domain example.com -wordlist wordlist.txt -threads 20 -timeout 10
+    ./DirSleuth -d example.com -w wordlist.txt -t 20 -timeout 10
    ```
 
 ## Development
@@ -91,5 +91,5 @@ We welcome contributions! If you want to improve DirSleuth:
 DirSleuth is licensed under the [MIT License](LICENSE). Feel free to use, modify, and distribute it under the terms of the license.
 
 ---
-For questions, suggestions, or issues, please open an [issue](https://github.com/yourusername/dirsleuth/issues) or contact us directly.
+For questions, suggestions, or issues, please open an [issue](https://github.com/Coding-for-Weeks/dirsleuth/issues) or contact us directly.
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ func main() {
 	results := make(chan string, threads)
 	var wg sync.WaitGroup
 	quit := make(chan struct{})
+	var closeOnce sync.Once
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -69,7 +70,7 @@ func main() {
 		}
 		if err := scanner.Err(); err != nil {
 			log.Printf("Error reading wordlist: %s\n", err)
-			close(quit)
+			closeOnce.Do(func() { close(quit) })
 		}
 	}()
 
@@ -85,5 +86,5 @@ func main() {
 	}
 
 	// Signal quit to goroutines in case of early exit
-	close(quit)
+	closeOnce.Do(func() { close(quit) })
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Coding-for-Weeks/dirsleuth
+
+go 1.21

--- a/tests/worker_test.go
+++ b/tests/worker_test.go
@@ -1,4 +1,4 @@
-package main
+package worker_test
 
 import (
 	"net/http"
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/Coding-for-Weeks/dirsleuth/internal/worker"
 )
 
 func TestWorker(t *testing.T) {
@@ -26,10 +28,11 @@ func TestWorker(t *testing.T) {
 
 	urls := make(chan string, 2)
 	results := make(chan string, 2)
+	quit := make(chan struct{})
 	var wg sync.WaitGroup
 
 	wg.Add(1)
-	go worker(client, urls, &wg, results)
+	go worker.Worker(client, urls, &wg, results, quit)
 
 	// Send test URLs to the worker
 	urls <- server.URL + "/valid"
@@ -39,6 +42,7 @@ func TestWorker(t *testing.T) {
 	// Wait for the worker to finish
 	wg.Wait()
 	close(results)
+	close(quit)
 
 	// Check results
 	expected := server.URL + "/valid"


### PR DESCRIPTION
## Summary
- fix Makefile to compile cmd/main.go and remove unused `-config` option
- add Go module support for reliable testing
- update README usage examples and issue link
- stop ignoring `config.json`
- prevent multiple closes of the quit channel
- correct worker tests to use package `worker`

## Testing
- `go test ./...`
- `make build`
- `make run` *(fails: Error: Target domain is required.)*